### PR TITLE
feat(inbox): configurable swipe dead zone with a live visual preview

### DIFF
--- a/app/src/main/kotlin/app/clearsms/data/backup/SettingsBackupManager.kt
+++ b/app/src/main/kotlin/app/clearsms/data/backup/SettingsBackupManager.kt
@@ -113,6 +113,7 @@ internal object SettingsBackupCatalog {
             SettingsBackupEntry.StringSetEntry("notification_actions"),
             SettingsBackupEntry.StringEntry("swipe_action_start"),
             SettingsBackupEntry.StringEntry("swipe_action_end"),
+            SettingsBackupEntry.StringEntry("swipe_dead_zone"),
             SettingsBackupEntry.StringEntry("default_destination"),
             SettingsBackupEntry.StringEntry("default_inbox_filter"),
             SettingsBackupEntry.StringEntry("default_finance_filter"),

--- a/app/src/main/kotlin/app/clearsms/data/prefs/SettingsRepository.kt
+++ b/app/src/main/kotlin/app/clearsms/data/prefs/SettingsRepository.kt
@@ -8,6 +8,7 @@ import app.clearsms.domain.model.OtpAutoDeletePolicy
 import app.clearsms.domain.model.OtpDisplaySize
 import app.clearsms.domain.model.StartDestination
 import app.clearsms.domain.model.SwipeAction
+import app.clearsms.domain.model.SwipeDeadZone
 import app.clearsms.domain.model.ThemeMode
 import app.clearsms.ui.alerts.AlertFilter
 import kotlinx.coroutines.flow.Flow
@@ -90,6 +91,11 @@ interface SettingsRepository {
     val swipeActionEnd: Flow<SwipeAction>
 
     suspend fun setSwipeActionEnd(value: SwipeAction)
+
+    /** Per-row band where a swipe never starts; off by default. */
+    val swipeDeadZone: Flow<SwipeDeadZone>
+
+    suspend fun setSwipeDeadZone(value: SwipeDeadZone)
 
     /** Bottom destination the app opens on. */
     val defaultDestination: Flow<StartDestination>

--- a/app/src/main/kotlin/app/clearsms/data/prefs/SettingsRepositoryImpl.kt
+++ b/app/src/main/kotlin/app/clearsms/data/prefs/SettingsRepositoryImpl.kt
@@ -16,6 +16,7 @@ import app.clearsms.domain.model.OtpAutoDeletePolicy
 import app.clearsms.domain.model.OtpDisplaySize
 import app.clearsms.domain.model.StartDestination
 import app.clearsms.domain.model.SwipeAction
+import app.clearsms.domain.model.SwipeDeadZone
 import app.clearsms.domain.model.ThemeMode
 import app.clearsms.ui.alerts.AlertFilter
 import kotlinx.coroutines.flow.Flow
@@ -125,6 +126,15 @@ class SettingsRepositoryImpl(
 
     override suspend fun setSwipeActionEnd(value: SwipeAction) {
         dataStore.edit { it[KEY_SWIPE_ACTION_END] = value.name }
+    }
+
+    override val swipeDeadZone: Flow<SwipeDeadZone> =
+        // decode is lenient: anything malformed falls back to the default
+        // (off), matching how other readers treat unknown stored values.
+        dataStore.data.map { SwipeDeadZone.decode(it[KEY_SWIPE_DEAD_ZONE]) }
+
+    override suspend fun setSwipeDeadZone(value: SwipeDeadZone) {
+        dataStore.edit { it[KEY_SWIPE_DEAD_ZONE] = value.encode() }
     }
 
     override val defaultDestination: Flow<StartDestination> =
@@ -262,6 +272,7 @@ class SettingsRepositoryImpl(
         val KEY_NOTIFICATION_ACTIONS = stringSetPreferencesKey("notification_actions")
         val KEY_SWIPE_ACTION_START = stringPreferencesKey("swipe_action_start")
         val KEY_SWIPE_ACTION_END = stringPreferencesKey("swipe_action_end")
+        val KEY_SWIPE_DEAD_ZONE = stringPreferencesKey("swipe_dead_zone")
         val KEY_DEFAULT_DESTINATION = stringPreferencesKey("default_destination")
         val KEY_DEFAULT_INBOX_FILTER = stringPreferencesKey("default_inbox_filter")
         val KEY_DEFAULT_FINANCE_FILTER = stringPreferencesKey("default_finance_filter")

--- a/app/src/main/kotlin/app/clearsms/domain/model/SwipeDeadZone.kt
+++ b/app/src/main/kotlin/app/clearsms/domain/model/SwipeDeadZone.kt
@@ -1,0 +1,130 @@
+package app.clearsms.domain.model
+
+/**
+ * A user-configurable "dead zone" on every inbox row where a horizontal
+ * swipe never starts (issue #16's suggested remedy, as extra insurance on
+ * top of the axis-dominance fix in the gesture itself).
+ *
+ * Interpretation: the zone is a BAND ON EACH ROW, not a region of the
+ * screen - the reporter asked for "a dead zone in the center of every
+ * message item", and a per-row band keeps the protected area under the
+ * thumb no matter where in the list the row currently sits. All values are
+ * PERCENTAGES of the row's own width/height rather than dp, so the zone
+ * covers the same share of every row on every device, font scale and
+ * orientation.
+ *
+ * - [centerXPercent]: horizontal centre of the band, as % of row width
+ *   (50 = centred). The band is clamped to stay fully inside the row.
+ * - [widthPercent]: band width as % of row width. Capped at [MAX_WIDTH]
+ *   (80%), which guarantees at least 20% of every row stays swipeable -
+ *   the zone can never silently disable swiping.
+ * - [heightPercent]: band height as % of row height, vertically centred.
+ *   Below 100%, thin strips at the row's top and bottom stay swipeable.
+ *
+ * [bounds] is THE single geometry source: the swipe gesture asks
+ * [blocksTouchAt] (implemented on top of [bounds]) and the settings preview
+ * draws the rectangle [bounds] returns, so the overlay the user sees while
+ * tuning is exactly the area the gesture ignores - they cannot drift.
+ */
+data class SwipeDeadZone(
+    val enabled: Boolean,
+    val centerXPercent: Int,
+    val widthPercent: Int,
+    val heightPercent: Int,
+) {
+    /** The zone with every value coerced into its legal range. */
+    fun sanitized(): SwipeDeadZone =
+        SwipeDeadZone(
+            enabled = enabled,
+            centerXPercent = centerXPercent.coerceIn(MIN_CENTER, MAX_CENTER),
+            widthPercent = widthPercent.coerceIn(MIN_WIDTH, MAX_WIDTH),
+            heightPercent = heightPercent.coerceIn(MIN_HEIGHT, MAX_HEIGHT),
+        )
+
+    /** The zone as fractions (0..1) of a row's width and height. */
+    data class Bounds(
+        val left: Float,
+        val top: Float,
+        val right: Float,
+        val bottom: Float,
+    )
+
+    /**
+     * The zone's rectangle in fractional row coordinates, or null when the
+     * feature is off. Single source of truth for both the gesture gate and
+     * the settings preview overlay.
+     */
+    fun bounds(): Bounds? {
+        if (!enabled) return null
+        val clean = sanitized()
+        val halfWidth = clean.widthPercent / 200f
+        val centerX = (clean.centerXPercent / 100f).coerceIn(halfWidth, 1f - halfWidth)
+        val halfHeight = clean.heightPercent / 200f
+        return Bounds(
+            left = centerX - halfWidth,
+            top = 0.5f - halfHeight,
+            right = centerX + halfWidth,
+            bottom = 0.5f + halfHeight,
+        )
+    }
+
+    /**
+     * Whether a touch at fractional row coordinates (x/rowWidth,
+     * y/rowHeight) falls inside the dead zone. Always false when disabled,
+     * so the off state is byte-for-byte today's behaviour.
+     */
+    fun blocksTouchAt(
+        xFraction: Float,
+        yFraction: Float,
+    ): Boolean {
+        val zone = bounds() ?: return false
+        return xFraction >= zone.left &&
+            xFraction <= zone.right &&
+            yFraction >= zone.top &&
+            yFraction <= zone.bottom
+    }
+
+    /** Serializes for the single `swipe_dead_zone` DataStore/backup key. */
+    fun encode(): String {
+        val clean = sanitized()
+        val flag = if (clean.enabled) "1" else "0"
+        return "v1:$flag:${clean.centerXPercent}:${clean.widthPercent}:${clean.heightPercent}"
+    }
+
+    companion object {
+        const val MIN_CENTER = 0
+        const val MAX_CENTER = 100
+        const val MIN_WIDTH = 10
+
+        /** ≤ 80% width keeps at least a fifth of every row swipeable. */
+        const val MAX_WIDTH = 80
+        const val MIN_HEIGHT = 25
+        const val MAX_HEIGHT = 100
+
+        /**
+         * Off by default (existing installs keep today's behaviour); the
+         * tuning values are what the zone shows when first switched on: a
+         * centred band over the middle 40% of the row's width and its full
+         * height - wide enough to scroll from anywhere near the middle,
+         * narrow enough that both row ends stay comfortably swipeable.
+         */
+        val DEFAULT = SwipeDeadZone(enabled = false, centerXPercent = 50, widthPercent = 40, heightPercent = 100)
+
+        /** Lenient inverse of [encode]: anything malformed falls back to [DEFAULT]. */
+        fun decode(stored: String?): SwipeDeadZone {
+            if (stored == null) return DEFAULT
+            val parts = stored.split(':')
+            if (parts.size != 5 || parts[0] != "v1") return DEFAULT
+            val enabled =
+                when (parts[1]) {
+                    "1" -> true
+                    "0" -> false
+                    else -> return DEFAULT
+                }
+            val center = parts[2].toIntOrNull() ?: return DEFAULT
+            val width = parts[3].toIntOrNull() ?: return DEFAULT
+            val height = parts[4].toIntOrNull() ?: return DEFAULT
+            return SwipeDeadZone(enabled, center, width, height).sanitized()
+        }
+    }
+}

--- a/app/src/main/kotlin/app/clearsms/ui/components/SwipeClaimVerdict.kt
+++ b/app/src/main/kotlin/app/clearsms/ui/components/SwipeClaimVerdict.kt
@@ -1,0 +1,52 @@
+package app.clearsms.ui.components
+
+import kotlin.math.abs
+
+/**
+ * Verdict for an in-progress touch on a swipeable inbox row (issue #16).
+ *
+ * Material's SwipeToDismissBox claims a gesture as soon as HORIZONTAL
+ * movement alone crosses touch slop - and because the row's drag detector
+ * runs before the list's scroll detector, a fast, slightly diagonal scroll
+ * flick can cross horizontal slop first and turn into a swipe. The fix is
+ * axis dominance: the row may only claim once horizontal movement both
+ * crosses slop AND strictly exceeds vertical movement, and it must yield as
+ * soon as vertical movement crosses slop without being dominated. Ties go
+ * to the scroll, because a stolen scroll is far more annoying than a swipe
+ * that needs a slightly flatter finger.
+ */
+enum class SwipeClaimVerdict {
+    /** Horizontal movement dominates past slop: the row owns the gesture. */
+    CLAIM,
+
+    /** Vertical movement crossed slop undominated: the scroll owns it. */
+    YIELD,
+
+    /** Not enough movement to decide yet. */
+    UNDECIDED,
+}
+
+/**
+ * Decides whether accumulated movement ([totalDx], [totalDy], both in px
+ * from the touch down) is a horizontal swipe, a vertical scroll, or still
+ * ambiguous. [touchSlop] is the platform's movement threshold in px.
+ *
+ * Pure and total: exercised directly by unit tests, and by the gesture loop
+ * in SwipeableMessageItem on every pointer event until it stops returning
+ * [SwipeClaimVerdict.UNDECIDED].
+ */
+fun evaluateSwipeClaim(
+    totalDx: Float,
+    totalDy: Float,
+    touchSlop: Float,
+): SwipeClaimVerdict {
+    val horizontal = abs(totalDx)
+    val vertical = abs(totalDy)
+    return when {
+        // Checked first so a movement that crosses slop on both axes at once
+        // (a fast diagonal) resolves as a scroll unless horizontal dominates.
+        vertical > touchSlop && vertical >= horizontal -> SwipeClaimVerdict.YIELD
+        horizontal > touchSlop && horizontal > vertical -> SwipeClaimVerdict.CLAIM
+        else -> SwipeClaimVerdict.UNDECIDED
+    }
+}

--- a/app/src/main/kotlin/app/clearsms/ui/components/SwipeableMessageItem.kt
+++ b/app/src/main/kotlin/app/clearsms/ui/components/SwipeableMessageItem.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import app.clearsms.R
 import app.clearsms.domain.model.SwipeAction
+import app.clearsms.domain.model.SwipeDeadZone
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
 import kotlin.math.sign
@@ -98,6 +99,7 @@ private fun RowSwipeAnchor.toDirection(): SwipeDirection? =
 fun SwipeableMessageItem(
     startAction: SwipeAction,
     endAction: SwipeAction,
+    deadZone: SwipeDeadZone,
     onAction: (SwipeAction) -> Unit,
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
@@ -152,7 +154,7 @@ fun SwipeableMessageItem(
     Box(
         modifier
             .onSizeChanged { size -> state.updateAnchors(anchorsFor(size.width)) }
-            .pointerInput(startEnabled, endEnabled, state) {
+            .pointerInput(startEnabled, endEnabled, deadZone, state) {
                 if (!startEnabled && !endEnabled) return@pointerInput
                 val slop = viewConfiguration.touchSlop
                 awaitEachGesture {
@@ -161,6 +163,19 @@ fun SwipeableMessageItem(
                     // still being handled (mirrors SwipeToDismissBox, which
                     // disables gestures until the state settles again).
                     if (state.currentValue != RowSwipeAnchor.SETTLED) return@awaitEachGesture
+                    // The user's dead zone: a touch starting inside the band
+                    // can scroll, tap or long-press, but never swipe. Uses the
+                    // same SwipeDeadZone.bounds() geometry the settings
+                    // preview draws, via blocksTouchAt.
+                    if (size.width > 0 &&
+                        size.height > 0 &&
+                        deadZone.blocksTouchAt(
+                            xFraction = down.position.x / size.width,
+                            yFraction = down.position.y / size.height,
+                        )
+                    ) {
+                        return@awaitEachGesture
+                    }
                     val tracker = VelocityTracker()
                     tracker.addPointerInputChange(down)
                     var totalDx = 0f

--- a/app/src/main/kotlin/app/clearsms/ui/components/SwipeableMessageItem.kt
+++ b/app/src/main/kotlin/app/clearsms/ui/components/SwipeableMessageItem.kt
@@ -23,7 +23,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -118,16 +117,6 @@ fun SwipeableMessageItem(
         }
     val startEnabled = startAction != SwipeAction.NONE
     val endEnabled = endAction != SwipeAction.NONE
-    LaunchedEffect(state.currentValue) {
-        val direction = state.currentValue.toDirection()
-        if (direction != null) {
-            val action = resolveSwipeAction(direction, startAction, endAction)
-            // The row always animates back to rest; the ViewModel hides the
-            // row through its own state so no dismissed gap is left behind.
-            state.animateTo(RowSwipeAnchor.SETTLED)
-            if (action != SwipeAction.NONE) onAction(action)
-        }
-    }
     val scope = rememberCoroutineScope()
     // Anchors in raw pointer coordinates, mirroring Material3: a disabled
     // direction simply has no anchor, so the offset clamps at rest and the
@@ -154,7 +143,7 @@ fun SwipeableMessageItem(
     Box(
         modifier
             .onSizeChanged { size -> state.updateAnchors(anchorsFor(size.width)) }
-            .pointerInput(startEnabled, endEnabled, deadZone, state) {
+            .pointerInput(startAction, endAction, deadZone, state) {
                 if (!startEnabled && !endEnabled) return@pointerInput
                 val slop = viewConfiguration.touchSlop
                 awaitEachGesture {
@@ -212,7 +201,24 @@ fun SwipeableMessageItem(
                         change.consume()
                     }
                     val velocity = tracker.calculateVelocity().x
-                    scope.launch { state.settle(velocity) }
+                    scope.launch {
+                        state.settle(velocity)
+                        // If the settle crossed a trigger anchor, perform the
+                        // action and bring the row back to rest ourselves.
+                        // (Doing this in a LaunchedEffect keyed on
+                        // state.currentValue self-cancels: the return
+                        // animation flips currentValue back to SETTLED, which
+                        // restarts the effect and kills the running
+                        // animation, freezing the row and dropping the
+                        // action.) The ViewModel hides the row through its
+                        // own state so no dismissed gap is left behind.
+                        val direction = state.currentValue.toDirection()
+                        if (direction != null) {
+                            val action = resolveSwipeAction(direction, startAction, endAction)
+                            if (action != SwipeAction.NONE) onAction(action)
+                            state.animateTo(RowSwipeAnchor.SETTLED)
+                        }
+                    }
                 }
             },
     ) {

--- a/app/src/main/kotlin/app/clearsms/ui/components/SwipeableMessageItem.kt
+++ b/app/src/main/kotlin/app/clearsms/ui/components/SwipeableMessageItem.kt
@@ -1,10 +1,19 @@
 package app.clearsms.ui.components
 
+import androidx.compose.animation.core.exponentialDecay
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.AnchoredDraggableState
+import androidx.compose.foundation.gestures.DraggableAnchors
+import androidx.compose.foundation.gestures.animateTo
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.horizontalDrag
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.absoluteOffset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Archive
@@ -12,31 +21,79 @@ import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.MarkEmailRead
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.SwipeToDismissBox
-import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.pointer.changedToUpIgnoreConsumed
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
+import androidx.compose.ui.input.pointer.util.VelocityTracker
+import androidx.compose.ui.input.pointer.util.addPointerInputChange
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import app.clearsms.R
 import app.clearsms.domain.model.SwipeAction
+import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
+import kotlin.math.sign
 
 /**
- * Wraps an inbox row in a [SwipeToDismissBox] whose two directions perform
- * the user-configured [startAction] / [endAction]. [SwipeAction.NONE]
+ * Distance the row must travel for a release to trigger the action, and the
+ * fling velocity that triggers it regardless of distance. Both are exactly
+ * Material3's SwipeToDismissBox defaults (56.dp positional, 125.dp/s
+ * velocity) so replacing the component changes gesture RECOGNITION only,
+ * never how far a recognised swipe must go.
+ */
+private val SwipePositionalThreshold = 56.dp
+private val SwipeVelocityThreshold = 125.dp
+
+/** Anchor values for the row's drag: rest, or fully revealed either way. */
+private enum class RowSwipeAnchor {
+    SETTLED,
+    START_TO_END,
+    END_TO_START,
+}
+
+private fun RowSwipeAnchor.toDirection(): SwipeDirection? =
+    when (this) {
+        RowSwipeAnchor.SETTLED -> null
+        RowSwipeAnchor.START_TO_END -> SwipeDirection.START_TO_END
+        RowSwipeAnchor.END_TO_START -> SwipeDirection.END_TO_START
+    }
+
+/**
+ * Wraps an inbox row in a horizontally draggable box whose two directions
+ * perform the user-configured [startAction] / [endAction]. [SwipeAction.NONE]
  * disables that direction entirely. The background shows the configured
  * action's icon and label while swiping.
  *
  * Every action runs immediately, Gmail-style: delete and archive surface a
  * transient UNDO snackbar (the system-provider deletion is deferred until
  * the undo window closes), so no blocking confirmation dialog is needed.
+ *
+ * Gesture recognition is deliberately NOT Material3's SwipeToDismissBox
+ * (issue #16): its drag detector claims the gesture as soon as horizontal
+ * movement crosses touch slop, so a slightly diagonal scroll flick swipes
+ * the row instead of scrolling the list. This implementation drives the same
+ * anchored-drag physics from its own pointer loop, which claims only on the
+ * axis-dominance verdict of [evaluateSwipeClaim] and yields to the list
+ * otherwise. Taps and long-presses pass through untouched (the row is only
+ * claimed after dominant horizontal movement past slop).
  */
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun SwipeableMessageItem(
     startAction: SwipeAction,
@@ -45,43 +102,130 @@ fun SwipeableMessageItem(
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
-    val state = rememberSwipeToDismissBoxState()
+    val density = LocalDensity.current
+    val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
+    val state =
+        remember(density) {
+            AnchoredDraggableState(
+                initialValue = RowSwipeAnchor.SETTLED,
+                positionalThreshold = { with(density) { SwipePositionalThreshold.toPx() } },
+                velocityThreshold = { with(density) { SwipeVelocityThreshold.toPx() } },
+                snapAnimationSpec = spring(),
+                decayAnimationSpec = exponentialDecay(),
+            )
+        }
+    val startEnabled = startAction != SwipeAction.NONE
+    val endEnabled = endAction != SwipeAction.NONE
     LaunchedEffect(state.currentValue) {
-        val direction =
-            when (state.currentValue) {
-                SwipeToDismissBoxValue.StartToEnd -> SwipeDirection.START_TO_END
-                SwipeToDismissBoxValue.EndToStart -> SwipeDirection.END_TO_START
-                SwipeToDismissBoxValue.Settled -> null
-            }
+        val direction = state.currentValue.toDirection()
         if (direction != null) {
             val action = resolveSwipeAction(direction, startAction, endAction)
             // The row always animates back to rest; the ViewModel hides the
             // row through its own state so no dismissed gap is left behind.
-            state.reset()
+            state.animateTo(RowSwipeAnchor.SETTLED)
             if (action != SwipeAction.NONE) onAction(action)
         }
     }
-    SwipeToDismissBox(
-        state = state,
-        modifier = modifier,
-        enableDismissFromStartToEnd = startAction != SwipeAction.NONE,
-        enableDismissFromEndToStart = endAction != SwipeAction.NONE,
-        backgroundContent = {
-            val startToEnd = state.dismissDirection == SwipeToDismissBoxValue.StartToEnd
-            val action = if (startToEnd) startAction else endAction
+    val scope = rememberCoroutineScope()
+    // Anchors in raw pointer coordinates, mirroring Material3: a disabled
+    // direction simply has no anchor, so the offset clamps at rest and the
+    // row cannot travel (or trigger) that way.
+    val anchorsFor = { widthPx: Int ->
+        val width = widthPx.toFloat()
+        DraggableAnchors {
+            RowSwipeAnchor.SETTLED at 0f
+            if (startEnabled) RowSwipeAnchor.START_TO_END at (if (isRtl) -width else width)
+            if (endEnabled) RowSwipeAnchor.END_TO_START at (if (isRtl) width else -width)
+        }
+    }
+    // The visually leading direction, derived from the raw offset sign.
+    val visualDirection by remember(isRtl) {
+        derivedStateOf {
+            val offset = state.offset
+            when {
+                offset.isNaN() || offset == 0f -> null
+                (offset > 0f) != isRtl -> SwipeDirection.START_TO_END
+                else -> SwipeDirection.END_TO_START
+            }
+        }
+    }
+    Box(
+        modifier
+            .onSizeChanged { size -> state.updateAnchors(anchorsFor(size.width)) }
+            .pointerInput(startEnabled, endEnabled, state) {
+                if (!startEnabled && !endEnabled) return@pointerInput
+                val slop = viewConfiguration.touchSlop
+                awaitEachGesture {
+                    val down = awaitFirstDown(requireUnconsumed = false)
+                    // Never grab a second gesture while a triggered swipe is
+                    // still being handled (mirrors SwipeToDismissBox, which
+                    // disables gestures until the state settles again).
+                    if (state.currentValue != RowSwipeAnchor.SETTLED) return@awaitEachGesture
+                    val tracker = VelocityTracker()
+                    tracker.addPointerInputChange(down)
+                    var totalDx = 0f
+                    var totalDy = 0f
+                    // Decision stage: accumulate movement until the gesture is
+                    // either claimed (dominant horizontal) or yielded.
+                    while (true) {
+                        val event = awaitPointerEvent()
+                        val change = event.changes.firstOrNull { it.id == down.id } ?: return@awaitEachGesture
+                        // Someone above us (an active list scroll intercepting in
+                        // the initial pass) already owns the gesture.
+                        if (change.isConsumed) return@awaitEachGesture
+                        if (change.changedToUpIgnoreConsumed()) return@awaitEachGesture
+                        val delta = change.positionChange()
+                        totalDx += delta.x
+                        totalDy += delta.y
+                        when (evaluateSwipeClaim(totalDx, totalDy, slop)) {
+                            SwipeClaimVerdict.YIELD -> return@awaitEachGesture
+                            SwipeClaimVerdict.UNDECIDED -> Unit
+                            SwipeClaimVerdict.CLAIM -> {
+                                tracker.addPointerInputChange(change)
+                                change.consume()
+                                // Start the drag from the slop edge, like the
+                                // platform detectors, so the row does not jump.
+                                state.dispatchRawDelta(totalDx - sign(totalDx) * slop)
+                                break
+                            }
+                        }
+                    }
+                    // Drag stage: the row owns the gesture; consume everything.
+                    horizontalDrag(down.id) { change ->
+                        tracker.addPointerInputChange(change)
+                        state.dispatchRawDelta(change.positionChange().x)
+                        change.consume()
+                    }
+                    val velocity = tracker.calculateVelocity().x
+                    scope.launch { state.settle(velocity) }
+                }
+            },
+    ) {
+        val direction = visualDirection
+        if (direction != null) {
+            val startToEnd = direction == SwipeDirection.START_TO_END
             SwipeActionBackground(
-                action = action,
+                action = if (startToEnd) startAction else endAction,
                 alignment = if (startToEnd) Alignment.CenterStart else Alignment.CenterEnd,
+                modifier = Modifier.matchParentSize(),
             )
-        },
-        content = { content() },
-    )
+        }
+        Box(
+            Modifier.absoluteOffset {
+                val offset = state.offset
+                IntOffset(if (offset.isNaN()) 0 else offset.roundToInt(), 0)
+            },
+        ) {
+            content()
+        }
+    }
 }
 
 @Composable
 private fun SwipeActionBackground(
     action: SwipeAction,
     alignment: Alignment,
+    modifier: Modifier = Modifier,
 ) {
     val icon: ImageVector?
     val label: String?
@@ -115,8 +259,7 @@ private fun SwipeActionBackground(
     }
     Box(
         modifier =
-            Modifier
-                .fillMaxSize()
+            modifier
                 .background(container)
                 .padding(horizontal = 24.dp),
         contentAlignment = alignment,

--- a/app/src/main/kotlin/app/clearsms/ui/inbox/InboxScreen.kt
+++ b/app/src/main/kotlin/app/clearsms/ui/inbox/InboxScreen.kt
@@ -347,6 +347,7 @@ fun InboxScreen(
                             // Swipes are disabled entirely while selecting.
                             startAction = if (selection.active) SwipeAction.NONE else state.swipeStart,
                             endAction = if (selection.active) SwipeAction.NONE else state.swipeEnd,
+                            deadZone = state.swipeDeadZone,
                             onAction = { action ->
                                 when (action) {
                                     SwipeAction.ARCHIVE -> viewModel.archive(item.message.id)

--- a/app/src/main/kotlin/app/clearsms/ui/inbox/InboxViewModel.kt
+++ b/app/src/main/kotlin/app/clearsms/ui/inbox/InboxViewModel.kt
@@ -19,6 +19,7 @@ import app.clearsms.di.IoDispatcher
 import app.clearsms.domain.model.Category
 import app.clearsms.domain.model.OtpDisplaySize
 import app.clearsms.domain.model.SwipeAction
+import app.clearsms.domain.model.SwipeDeadZone
 import app.clearsms.sms.ContactsSource
 import app.clearsms.ui.common.RelativeTime
 import app.clearsms.ui.common.UndoUiEvent
@@ -114,6 +115,8 @@ data class InboxUiState(
     val otpDisplaySize: OtpDisplaySize = OtpDisplaySize.DEFAULT,
     val swipeStart: SwipeAction = SwipeAction.ARCHIVE,
     val swipeEnd: SwipeAction = SwipeAction.DELETE,
+    /** Per-row band where a swipe never starts; off by default. */
+    val swipeDeadZone: SwipeDeadZone = SwipeDeadZone.DEFAULT,
     /** Automatic post-update re-sort in flight; null hides the banner. */
     val sortingBanner: SortingBanner? = null,
 )
@@ -231,6 +234,8 @@ class InboxViewModel
             val swipeStart: SwipeAction,
             val swipeEnd: SwipeAction,
             val pillOrder: List<Category>,
+            /** Filled by the second combine stage (combine() maxes out at 5 flows). */
+            val swipeDeadZone: SwipeDeadZone = SwipeDeadZone.DEFAULT,
         )
 
         private val chrome =
@@ -241,6 +246,7 @@ class InboxViewModel
                 settings.swipeActionEnd,
                 settings.inboxPillOrder,
             ) { rich, otpSize, start, end, order -> Chrome(rich, otpSize, start, end, order) }
+                .combine(settings.swipeDeadZone) { chrome, zone -> chrome.copy(swipeDeadZone = zone) }
 
         val uiState: StateFlow<InboxUiState> =
             combine(
@@ -259,6 +265,7 @@ class InboxViewModel
                     otpDisplaySize = chromeState.otpDisplaySize,
                     swipeStart = chromeState.swipeStart,
                     swipeEnd = chromeState.swipeEnd,
+                    swipeDeadZone = chromeState.swipeDeadZone,
                     pillOrder = chromeState.pillOrder,
                     sortingBanner = sorting,
                 )

--- a/app/src/main/kotlin/app/clearsms/ui/settings/SettingsCatalog.kt
+++ b/app/src/main/kotlin/app/clearsms/ui/settings/SettingsCatalog.kt
@@ -54,6 +54,7 @@ enum class SettingsItem(
     DEFAULT_INBOX_FILTER(SettingsSection.INBOX, R.string.settings_default_inbox_filter),
     SWIPE_RIGHT(SettingsSection.INBOX, R.string.settings_swipe_right),
     SWIPE_LEFT(SettingsSection.INBOX, R.string.settings_swipe_left),
+    SWIPE_DEAD_ZONE(SettingsSection.INBOX, R.string.settings_swipe_dead_zone),
     SORT_AGAIN(SettingsSection.INBOX, R.string.settings_sort_again),
     FINANCE_PILL_ORDER(SettingsSection.FINANCE, R.string.settings_pill_order),
     SHOW_BALANCE(SettingsSection.FINANCE, R.string.settings_show_balance),

--- a/app/src/main/kotlin/app/clearsms/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/app/clearsms/ui/settings/SettingsScreen.kt
@@ -79,6 +79,7 @@ import app.clearsms.domain.model.OtpAutoDeletePolicy
 import app.clearsms.domain.model.OtpDisplaySize
 import app.clearsms.domain.model.StartDestination
 import app.clearsms.domain.model.SwipeAction
+import app.clearsms.domain.model.SwipeDeadZone
 import app.clearsms.domain.model.ThemeMode
 import app.clearsms.ui.alerts.AlertFilter
 import app.clearsms.ui.alerts.displayName
@@ -105,6 +106,7 @@ private enum class SettingsDialog {
     NOTIFICATION_ACTIONS,
     SWIPE_START,
     SWIPE_END,
+    SWIPE_DEAD_ZONE,
     DEFAULT_SCREEN,
     DEFAULT_FILTER,
     DEFAULT_FINANCE_FILTER,
@@ -534,6 +536,12 @@ fun SettingsScreen(
                 },
                 onDismiss = { dialog = null },
             )
+        SettingsDialog.SWIPE_DEAD_ZONE ->
+            SwipeDeadZoneDialog(
+                value = state.swipeDeadZone,
+                onChange = viewModel::setSwipeDeadZone,
+                onDismiss = { dialog = null },
+            )
         SettingsDialog.DEFAULT_SCREEN ->
             RadioDialog(
                 title = stringResource(R.string.settings_default_screen),
@@ -865,6 +873,10 @@ private fun settingsRowEntries(
                 SettingsItem.SWIPE_LEFT ->
                     row(section, title, swipeActionLabel(state.swipeActionEnd)) {
                         openDialog(SettingsDialog.SWIPE_END)
+                    }
+                SettingsItem.SWIPE_DEAD_ZONE ->
+                    row(section, title, swipeDeadZoneSummary(state.swipeDeadZone)) {
+                        openDialog(SettingsDialog.SWIPE_DEAD_ZONE)
                     }
                 SettingsItem.SORT_AGAIN -> {
                     val sortSummary = stringResource(R.string.settings_sort_again_summary)
@@ -1566,6 +1578,14 @@ private fun notificationActionsSummary(actions: Set<NotificationAction>): String
             .filter { it in actions }
             .map { notificationActionLabel(it) }
             .joinToString(separator = ", ")
+    }
+
+@Composable
+private fun swipeDeadZoneSummary(zone: SwipeDeadZone): String =
+    if (zone.enabled) {
+        stringResource(R.string.settings_swipe_dead_zone_summary_on, zone.widthPercent)
+    } else {
+        stringResource(R.string.settings_swipe_dead_zone_summary_off)
     }
 
 @Composable

--- a/app/src/main/kotlin/app/clearsms/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/app/clearsms/ui/settings/SettingsViewModel.kt
@@ -22,6 +22,7 @@ import app.clearsms.domain.model.OtpAutoDeletePolicy
 import app.clearsms.domain.model.OtpDisplaySize
 import app.clearsms.domain.model.StartDestination
 import app.clearsms.domain.model.SwipeAction
+import app.clearsms.domain.model.SwipeDeadZone
 import app.clearsms.domain.model.ThemeMode
 import app.clearsms.ui.alerts.AlertFilter
 import app.clearsms.ui.common.BackupFrequency
@@ -64,6 +65,8 @@ data class SettingsUiState(
     val logoBackground: LogoBackground = LogoBackground.NONE,
     val swipeActionStart: SwipeAction = SwipeAction.ARCHIVE,
     val swipeActionEnd: SwipeAction = SwipeAction.DELETE,
+    /** Per-row band where a swipe never starts; off by default. */
+    val swipeDeadZone: SwipeDeadZone = SwipeDeadZone.DEFAULT,
     val defaultDestination: StartDestination = StartDestination.INBOX,
     val defaultInboxFilter: Category? = Category.IMPORTANT,
     val defaultFinanceFilter: FinanceTab = FinanceTab.ACCOUNTS,
@@ -242,6 +245,8 @@ class SettingsViewModel
             val destination: StartDestination,
             val inboxFilter: Category?,
             val financeFilter: FinanceTab,
+            /** Filled by the second combine stage (combine() maxes out at 5 flows). */
+            val swipeDeadZone: SwipeDeadZone = SwipeDeadZone.DEFAULT,
         )
 
         private val appearance =
@@ -272,7 +277,9 @@ class SettingsViewModel
                 settings.defaultInboxFilter,
                 settings.defaultFinanceFilter,
                 ::GestureStartupState,
-            )
+            ).combine(settings.swipeDeadZone) { gestures, zone ->
+                gestures.copy(swipeDeadZone = zone)
+            }
         private val otp =
             combine(settings.otpAutoCopy, settings.otpAutoDeletePolicy, settings.otpDisplaySize, ::Triple)
 
@@ -325,6 +332,7 @@ class SettingsViewModel
                     transactionNotifications = notificationState.transactionNotifications,
                     swipeActionStart = gestures.swipeStart,
                     swipeActionEnd = gestures.swipeEnd,
+                    swipeDeadZone = gestures.swipeDeadZone,
                     defaultDestination = gestures.destination,
                     defaultInboxFilter = gestures.inboxFilter,
                     defaultFinanceFilter = gestures.financeFilter,
@@ -384,6 +392,8 @@ class SettingsViewModel
         fun setSwipeActionStart(value: SwipeAction) = launchIo { settings.setSwipeActionStart(value) }
 
         fun setSwipeActionEnd(value: SwipeAction) = launchIo { settings.setSwipeActionEnd(value) }
+
+        fun setSwipeDeadZone(value: SwipeDeadZone) = launchIo { settings.setSwipeDeadZone(value) }
 
         fun setDefaultDestination(value: StartDestination) = launchIo { settings.setDefaultDestination(value) }
 

--- a/app/src/main/kotlin/app/clearsms/ui/settings/SwipeDeadZoneDialog.kt
+++ b/app/src/main/kotlin/app/clearsms/ui/settings/SwipeDeadZoneDialog.kt
@@ -1,0 +1,237 @@
+package app.clearsms.ui.settings
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import app.clearsms.R
+import app.clearsms.domain.model.SwipeDeadZone
+import kotlin.math.roundToInt
+
+/**
+ * Editor for the per-row swipe dead zone (issue #16): an enable switch, a
+ * realistic three-row inbox preview with the zone shaded live on every row,
+ * and Position / Width / Height sliders.
+ *
+ * The preview is honest by construction: the shaded rectangle is drawn from
+ * [SwipeDeadZone.bounds] - the SAME geometry the swipe gesture consults
+ * through [SwipeDeadZone.blocksTouchAt] - so what the user sees is exactly
+ * where swipes will not start. Sliders (not drag handles) keep the feature
+ * fully configurable without fine motor control; slider positions update the
+ * overlay while dragging and persist when the drag ends.
+ */
+@Composable
+internal fun SwipeDeadZoneDialog(
+    value: SwipeDeadZone,
+    onChange: (SwipeDeadZone) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    // Local copy so the overlay tracks the slider mid-drag; every committed
+    // change (switch toggle, slider release) is persisted through onChange.
+    var current by remember { mutableStateOf(value.sanitized()) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.settings_swipe_dead_zone)) },
+        text = {
+            Column(
+                modifier = Modifier.verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = stringResource(R.string.settings_swipe_dead_zone_enable),
+                        modifier = Modifier.weight(1f),
+                    )
+                    Switch(
+                        checked = current.enabled,
+                        onCheckedChange = {
+                            current = current.copy(enabled = it)
+                            onChange(current)
+                        },
+                    )
+                }
+                DeadZonePreview(zone = current)
+                Text(
+                    text = stringResource(R.string.settings_swipe_dead_zone_hint),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                PercentSlider(
+                    label = stringResource(R.string.settings_swipe_dead_zone_position),
+                    value = current.centerXPercent,
+                    valueRange = SwipeDeadZone.MIN_CENTER..SwipeDeadZone.MAX_CENTER,
+                    enabled = current.enabled,
+                    onValueChange = { current = current.copy(centerXPercent = it) },
+                    onValueChangeFinished = { onChange(current) },
+                )
+                PercentSlider(
+                    label = stringResource(R.string.settings_swipe_dead_zone_width),
+                    value = current.widthPercent,
+                    valueRange = SwipeDeadZone.MIN_WIDTH..SwipeDeadZone.MAX_WIDTH,
+                    enabled = current.enabled,
+                    onValueChange = { current = current.copy(widthPercent = it) },
+                    onValueChangeFinished = { onChange(current) },
+                )
+                PercentSlider(
+                    label = stringResource(R.string.settings_swipe_dead_zone_height),
+                    value = current.heightPercent,
+                    valueRange = SwipeDeadZone.MIN_HEIGHT..SwipeDeadZone.MAX_HEIGHT,
+                    enabled = current.enabled,
+                    onValueChange = { current = current.copy(heightPercent = it) },
+                    onValueChangeFinished = { onChange(current) },
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.action_done)) }
+        },
+    )
+}
+
+/**
+ * Three mock inbox rows with the dead zone shaded on each. The overlay
+ * rectangle comes from [SwipeDeadZone.bounds] scaled to the row's size -
+ * geometry is never re-derived here, so preview and gesture cannot drift
+ * (pinned by SwipeDeadZoneGeometryConventionTest).
+ */
+@Composable
+private fun DeadZonePreview(
+    zone: SwipeDeadZone,
+    modifier: Modifier = Modifier,
+) {
+    val overlayColor = MaterialTheme.colorScheme.primary
+    val description = stringResource(R.string.settings_swipe_dead_zone_preview_description)
+    Column(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(12.dp))
+                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f))
+                .semantics { contentDescription = description },
+    ) {
+        repeat(3) { index ->
+            Box(Modifier.fillMaxWidth()) {
+                MockInboxRow(index)
+                val bounds = zone.bounds()
+                if (bounds != null) {
+                    Canvas(Modifier.matchParentSize()) {
+                        drawRect(
+                            color = overlayColor.copy(alpha = 0.30f),
+                            topLeft = Offset(bounds.left * size.width, bounds.top * size.height),
+                            size =
+                                Size(
+                                    width = (bounds.right - bounds.left) * size.width,
+                                    height = (bounds.bottom - bounds.top) * size.height,
+                                ),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/** A schematic inbox row: avatar circle plus two text-shaped bars. */
+@Composable
+private fun MockInboxRow(index: Int) {
+    val barColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.35f)
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 12.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            Modifier
+                .size(36.dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.secondaryContainer),
+        )
+        Spacer(Modifier.width(12.dp))
+        Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Box(
+                Modifier
+                    .fillMaxWidth(fraction = 0.45f + index * 0.1f)
+                    .height(10.dp)
+                    .clip(RoundedCornerShape(5.dp))
+                    .background(barColor),
+            )
+            Box(
+                Modifier
+                    .fillMaxWidth(fraction = 0.8f - index * 0.08f)
+                    .height(8.dp)
+                    .clip(RoundedCornerShape(4.dp))
+                    .background(barColor.copy(alpha = 0.25f)),
+            )
+        }
+    }
+}
+
+/** Labelled 0-100% slider with a live value readout. */
+@Composable
+private fun PercentSlider(
+    label: String,
+    value: Int,
+    valueRange: IntRange,
+    enabled: Boolean,
+    onValueChange: (Int) -> Unit,
+    onValueChangeFinished: () -> Unit,
+) {
+    Column {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(text = label, style = MaterialTheme.typography.labelLarge)
+            Text(
+                text = stringResource(R.string.settings_swipe_dead_zone_percent, value),
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Slider(
+            value = value.toFloat(),
+            onValueChange = { onValueChange(it.roundToInt()) },
+            valueRange = valueRange.first.toFloat()..valueRange.last.toFloat(),
+            enabled = enabled,
+            onValueChangeFinished = onValueChangeFinished,
+            modifier = Modifier.semantics { contentDescription = label },
+        )
+    }
+}

--- a/app/src/main/res/values/strings_ui.xml
+++ b/app/src/main/res/values/strings_ui.xml
@@ -313,6 +313,16 @@
     <string name="settings_transaction_notifications_summary">Show the parsed amount instead of the raw message</string>
     <string name="settings_swipe_right">Swipe right action</string>
     <string name="settings_swipe_left">Swipe left action</string>
+    <string name="settings_swipe_dead_zone">Swipe dead zone</string>
+    <string name="settings_swipe_dead_zone_summary_off">Off - swipes start anywhere on a row</string>
+    <string name="settings_swipe_dead_zone_summary_on">On - %1$d%% wide band on every row</string>
+    <string name="settings_swipe_dead_zone_enable">Use dead zone</string>
+    <string name="settings_swipe_dead_zone_hint">Swipes never start inside the shaded band. The rest of the row always stays swipeable, and taps and scrolling work everywhere.</string>
+    <string name="settings_swipe_dead_zone_position">Position</string>
+    <string name="settings_swipe_dead_zone_width">Width</string>
+    <string name="settings_swipe_dead_zone_height">Height</string>
+    <string name="settings_swipe_dead_zone_percent">%1$d%%</string>
+    <string name="settings_swipe_dead_zone_preview_description">Preview of three inbox rows with the swipe dead zone shaded on each</string>
     <string name="settings_section_startup">Startup</string>
     <string name="settings_default_screen">Default screen</string>
     <string name="settings_default_inbox_filter">Default inbox filter</string>

--- a/app/src/test/kotlin/app/clearsms/data/backup/SettingsBackupManagerTest.kt
+++ b/app/src/test/kotlin/app/clearsms/data/backup/SettingsBackupManagerTest.kt
@@ -13,6 +13,7 @@ import app.clearsms.domain.model.OtpAutoDeletePolicy
 import app.clearsms.domain.model.OtpDisplaySize
 import app.clearsms.domain.model.StartDestination
 import app.clearsms.domain.model.SwipeAction
+import app.clearsms.domain.model.SwipeDeadZone
 import app.clearsms.domain.model.ThemeMode
 import app.clearsms.ui.alerts.AlertFilter
 import com.google.common.truth.Truth.assertThat
@@ -64,6 +65,7 @@ class SettingsBackupManagerTest {
         repo.setNotificationActions(setOf(NotificationAction.SHARE, NotificationAction.COPY_OTP))
         repo.setSwipeActionStart(SwipeAction.TOGGLE_READ)
         repo.setSwipeActionEnd(SwipeAction.NONE)
+        repo.setSwipeDeadZone(SwipeDeadZone(enabled = true, centerXPercent = 30, widthPercent = 60, heightPercent = 50))
         repo.setDefaultDestination(StartDestination.FINANCE)
         repo.setDefaultInboxFilter(null)
         repo.setDefaultFinanceFilter(FinanceTab.CREDIT_CARDS)
@@ -89,6 +91,8 @@ class SettingsBackupManagerTest {
             .isEqualTo(setOf(NotificationAction.SHARE, NotificationAction.COPY_OTP))
         assertThat(repo.swipeActionStart.first()).isEqualTo(SwipeAction.TOGGLE_READ)
         assertThat(repo.swipeActionEnd.first()).isEqualTo(SwipeAction.NONE)
+        assertThat(repo.swipeDeadZone.first())
+            .isEqualTo(SwipeDeadZone(enabled = true, centerXPercent = 30, widthPercent = 60, heightPercent = 50))
         assertThat(repo.defaultDestination.first()).isEqualTo(StartDestination.FINANCE)
         assertThat(repo.defaultInboxFilter.first()).isNull()
         assertThat(repo.defaultFinanceFilter.first()).isEqualTo(FinanceTab.CREDIT_CARDS)

--- a/app/src/test/kotlin/app/clearsms/data/prefs/SettingsRepositoryImplTest.kt
+++ b/app/src/test/kotlin/app/clearsms/data/prefs/SettingsRepositoryImplTest.kt
@@ -13,6 +13,7 @@ import app.clearsms.domain.model.NotificationAction
 import app.clearsms.domain.model.OtpDisplaySize
 import app.clearsms.domain.model.StartDestination
 import app.clearsms.domain.model.SwipeAction
+import app.clearsms.domain.model.SwipeDeadZone
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -111,6 +112,33 @@ class SettingsRepositoryImplTest {
             repo.setSwipeActionEnd(SwipeAction.NONE)
             assertThat(repo.swipeActionStart.first()).isEqualTo(SwipeAction.TOGGLE_READ)
             assertThat(repo.swipeActionEnd.first()).isEqualTo(SwipeAction.NONE)
+        }
+
+    @Test
+    fun `swipe dead zone round trips, defaults off, and clamps out-of-range values`() =
+        runBlocking {
+            val repo = repository()
+            assertThat(repo.swipeDeadZone.first()).isEqualTo(SwipeDeadZone.DEFAULT)
+            val zone = SwipeDeadZone(enabled = true, centerXPercent = 30, widthPercent = 60, heightPercent = 50)
+            repo.setSwipeDeadZone(zone)
+            assertThat(repo.swipeDeadZone.first()).isEqualTo(zone)
+            // Out-of-range values are sanitized on write, so no reader can
+            // ever observe a zone that would cover the whole row.
+            repo.setSwipeDeadZone(SwipeDeadZone(enabled = true, centerXPercent = 500, widthPercent = 100, heightPercent = 0))
+            val clamped = repo.swipeDeadZone.first()
+            assertThat(clamped.widthPercent).isEqualTo(SwipeDeadZone.MAX_WIDTH)
+            assertThat(clamped.centerXPercent).isEqualTo(SwipeDeadZone.MAX_CENTER)
+            assertThat(clamped.heightPercent).isEqualTo(SwipeDeadZone.MIN_HEIGHT)
+        }
+
+    @Test
+    fun `corrupt swipe dead zone value falls back to the default without throwing`() =
+        runBlocking {
+            val repo = repository()
+            dataStore.edit { prefs ->
+                prefs[stringPreferencesKey("swipe_dead_zone")] = "not a zone at all"
+            }
+            assertThat(repo.swipeDeadZone.first()).isEqualTo(SwipeDeadZone.DEFAULT)
         }
 
     @Test

--- a/app/src/test/kotlin/app/clearsms/domain/model/SwipeDeadZoneTest.kt
+++ b/app/src/test/kotlin/app/clearsms/domain/model/SwipeDeadZoneTest.kt
@@ -1,0 +1,158 @@
+package app.clearsms.domain.model
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Pins the dead zone's pure geometry (issue #16): touch containment, bounds
+ * clamping, the off state, the guarantee that a maximal zone still leaves
+ * part of every row swipeable, the storage round trip, and - critically -
+ * that [SwipeDeadZone.blocksTouchAt] agrees exactly with the rectangle
+ * [SwipeDeadZone.bounds] returns, because the settings preview draws that
+ * rectangle while the gesture consults blocksTouchAt.
+ */
+class SwipeDeadZoneTest {
+    @Test
+    fun `disabled zone blocks nothing and has no bounds`() {
+        val zone = SwipeDeadZone.DEFAULT
+        assertThat(zone.enabled).isFalse()
+        assertThat(zone.bounds()).isNull()
+        // The off state is exactly today's behaviour: no coordinate blocks.
+        for (x in 0..10) {
+            for (y in 0..10) {
+                assertThat(zone.blocksTouchAt(x / 10f, y / 10f)).isFalse()
+            }
+        }
+    }
+
+    @Test
+    fun `a centred default-tuning zone blocks the middle and frees the edges`() {
+        val zone = SwipeDeadZone.DEFAULT.copy(enabled = true)
+        // Centre 50%, width 40%, height 100%: band spans x in 0.3..0.7.
+        assertThat(zone.blocksTouchAt(0.5f, 0.5f)).isTrue()
+        assertThat(zone.blocksTouchAt(0.31f, 0.05f)).isTrue()
+        assertThat(zone.blocksTouchAt(0.69f, 0.95f)).isTrue()
+        assertThat(zone.blocksTouchAt(0.29f, 0.5f)).isFalse()
+        assertThat(zone.blocksTouchAt(0.71f, 0.5f)).isFalse()
+        assertThat(zone.blocksTouchAt(0.05f, 0.5f)).isFalse()
+        assertThat(zone.blocksTouchAt(0.95f, 0.5f)).isFalse()
+    }
+
+    @Test
+    fun `height below 100 percent frees strips at the row top and bottom`() {
+        val zone = SwipeDeadZone(enabled = true, centerXPercent = 50, widthPercent = 40, heightPercent = 50)
+        // Band spans y in 0.25..0.75.
+        assertThat(zone.blocksTouchAt(0.5f, 0.5f)).isTrue()
+        assertThat(zone.blocksTouchAt(0.5f, 0.2f)).isFalse()
+        assertThat(zone.blocksTouchAt(0.5f, 0.8f)).isFalse()
+    }
+
+    @Test
+    fun `the zone is clamped to stay inside the row when positioned at an edge`() {
+        val zone = SwipeDeadZone(enabled = true, centerXPercent = 0, widthPercent = 40, heightPercent = 100)
+        val bounds = requireNotNull(zone.bounds())
+        assertThat(bounds.left).isEqualTo(0f)
+        assertThat(bounds.right).isEqualTo(0.4f)
+
+        val right = SwipeDeadZone(enabled = true, centerXPercent = 100, widthPercent = 40, heightPercent = 100)
+        val rightBounds = requireNotNull(right.bounds())
+        assertThat(rightBounds.left).isEqualTo(0.6f)
+        assertThat(rightBounds.right).isEqualTo(1f)
+    }
+
+    @Test
+    fun `sanitized coerces every value into its legal range`() {
+        val wild = SwipeDeadZone(enabled = true, centerXPercent = 400, widthPercent = 100, heightPercent = -5)
+        val clean = wild.sanitized()
+        assertThat(clean.centerXPercent).isEqualTo(SwipeDeadZone.MAX_CENTER)
+        assertThat(clean.widthPercent).isEqualTo(SwipeDeadZone.MAX_WIDTH)
+        assertThat(clean.heightPercent).isEqualTo(SwipeDeadZone.MIN_HEIGHT)
+    }
+
+    @Test
+    fun `even the maximal zone leaves at least a fifth of every row swipeable`() {
+        // MAX_WIDTH is the bound that stops the dead zone from silently
+        // disabling swipes: no position can cover the whole row width.
+        for (center in SwipeDeadZone.MIN_CENTER..SwipeDeadZone.MAX_CENTER step 5) {
+            val zone =
+                SwipeDeadZone(
+                    enabled = true,
+                    centerXPercent = center,
+                    widthPercent = SwipeDeadZone.MAX_WIDTH,
+                    heightPercent = SwipeDeadZone.MAX_HEIGHT,
+                )
+            val bounds = requireNotNull(zone.bounds())
+            val covered = bounds.right - bounds.left
+            assertThat(covered).isLessThan(0.801f)
+            // The free 20% is contiguous on one side or split across both,
+            // but always present (tolerance for float rounding).
+            val free = bounds.left + (1f - bounds.right)
+            assertThat(free).isGreaterThan(0.199f)
+        }
+    }
+
+    @Test
+    fun `blocksTouchAt agrees exactly with the bounds rectangle the preview draws`() {
+        // The settings preview shades bounds(); the gesture asks
+        // blocksTouchAt(). This agreement is what makes the preview honest.
+        val samples =
+            listOf(
+                SwipeDeadZone.DEFAULT,
+                SwipeDeadZone.DEFAULT.copy(enabled = true),
+                SwipeDeadZone(enabled = true, centerXPercent = 20, widthPercent = 60, heightPercent = 50),
+                SwipeDeadZone(enabled = true, centerXPercent = 90, widthPercent = 10, heightPercent = 25),
+                SwipeDeadZone(enabled = true, centerXPercent = 0, widthPercent = 80, heightPercent = 100),
+            )
+        samples.forEach { zone ->
+            val bounds = zone.bounds()
+            for (xi in 0..20) {
+                for (yi in 0..20) {
+                    val x = xi / 20f
+                    val y = yi / 20f
+                    val inRect =
+                        bounds != null &&
+                            x >= bounds.left &&
+                            x <= bounds.right &&
+                            y >= bounds.top &&
+                            y <= bounds.bottom
+                    assertThat(zone.blocksTouchAt(x, y)).isEqualTo(inRect)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `encode and decode round trip`() {
+        val zone = SwipeDeadZone(enabled = true, centerXPercent = 35, widthPercent = 55, heightPercent = 70)
+        assertThat(SwipeDeadZone.decode(zone.encode())).isEqualTo(zone)
+        val off = SwipeDeadZone(enabled = false, centerXPercent = 60, widthPercent = 25, heightPercent = 100)
+        // Tuning survives the off state, so re-enabling restores it.
+        assertThat(SwipeDeadZone.decode(off.encode())).isEqualTo(off)
+    }
+
+    @Test
+    fun `decode is lenient about garbage`() {
+        listOf(
+            null,
+            "",
+            "v1",
+            "v2:1:50:40:100",
+            "v1:maybe:50:40:100",
+            "v1:1:fifty:40:100",
+            "v1:1:50:40",
+            "v1:1:50:40:100:extra",
+        ).forEach { stored ->
+            assertThat(SwipeDeadZone.decode(stored)).isEqualTo(SwipeDeadZone.DEFAULT)
+        }
+        // Out-of-range stored values are clamped, not rejected.
+        assertThat(SwipeDeadZone.decode("v1:1:200:99:5"))
+            .isEqualTo(
+                SwipeDeadZone(
+                    enabled = true,
+                    centerXPercent = SwipeDeadZone.MAX_CENTER,
+                    widthPercent = SwipeDeadZone.MAX_WIDTH,
+                    heightPercent = SwipeDeadZone.MIN_HEIGHT,
+                ),
+            )
+    }
+}

--- a/app/src/test/kotlin/app/clearsms/testing/FakeSettingsRepository.kt
+++ b/app/src/test/kotlin/app/clearsms/testing/FakeSettingsRepository.kt
@@ -9,6 +9,7 @@ import app.clearsms.domain.model.OtpAutoDeletePolicy
 import app.clearsms.domain.model.OtpDisplaySize
 import app.clearsms.domain.model.StartDestination
 import app.clearsms.domain.model.SwipeAction
+import app.clearsms.domain.model.SwipeDeadZone
 import app.clearsms.domain.model.ThemeMode
 import app.clearsms.ui.alerts.AlertFilter
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -82,6 +83,10 @@ open class FakeSettingsRepository : SettingsRepository {
     override val swipeActionEnd = MutableStateFlow(SwipeAction.DELETE)
 
     override suspend fun setSwipeActionEnd(value: SwipeAction) = Unit
+
+    override val swipeDeadZone = MutableStateFlow(SwipeDeadZone.DEFAULT)
+
+    override suspend fun setSwipeDeadZone(value: SwipeDeadZone) = Unit
 
     override val defaultDestination = MutableStateFlow(StartDestination.INBOX)
 

--- a/app/src/test/kotlin/app/clearsms/ui/components/SwipeClaimTest.kt
+++ b/app/src/test/kotlin/app/clearsms/ui/components/SwipeClaimTest.kt
@@ -1,0 +1,74 @@
+package app.clearsms.ui.components
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Pins the axis-dominance discipline that keeps a vertical scroll from
+ * turning into a horizontal swipe (issue #16): the row claims the gesture
+ * only when horizontal movement crosses touch slop AND strictly dominates
+ * vertical movement; it yields as soon as vertical movement crosses slop
+ * undominated; ties go to the scroll.
+ */
+class SwipeClaimTest {
+    private val slop = 24f
+
+    @Test
+    fun `dominant horizontal movement past slop claims the gesture`() {
+        assertThat(evaluateSwipeClaim(totalDx = 30f, totalDy = 4f, touchSlop = slop))
+            .isEqualTo(SwipeClaimVerdict.CLAIM)
+        // Direction does not matter, magnitude does.
+        assertThat(evaluateSwipeClaim(totalDx = -30f, totalDy = -4f, touchSlop = slop))
+            .isEqualTo(SwipeClaimVerdict.CLAIM)
+    }
+
+    @Test
+    fun `a scroll-like gesture yields even when its horizontal component crosses slop`() {
+        // The reporter's case: a fast, slightly diagonal scroll flick whose
+        // horizontal component alone would satisfy SwipeToDismissBox.
+        assertThat(evaluateSwipeClaim(totalDx = 30f, totalDy = 60f, touchSlop = slop))
+            .isEqualTo(SwipeClaimVerdict.YIELD)
+        assertThat(evaluateSwipeClaim(totalDx = -26f, totalDy = 80f, touchSlop = slop))
+            .isEqualTo(SwipeClaimVerdict.YIELD)
+    }
+
+    @Test
+    fun `vertical movement past slop yields`() {
+        assertThat(evaluateSwipeClaim(totalDx = 0f, totalDy = 25f, touchSlop = slop))
+            .isEqualTo(SwipeClaimVerdict.YIELD)
+        assertThat(evaluateSwipeClaim(totalDx = 2f, totalDy = -40f, touchSlop = slop))
+            .isEqualTo(SwipeClaimVerdict.YIELD)
+    }
+
+    @Test
+    fun `a perfect diagonal past slop goes to the scroll, not the swipe`() {
+        assertThat(evaluateSwipeClaim(totalDx = 40f, totalDy = 40f, touchSlop = slop))
+            .isEqualTo(SwipeClaimVerdict.YIELD)
+        assertThat(evaluateSwipeClaim(totalDx = -40f, totalDy = 40f, touchSlop = slop))
+            .isEqualTo(SwipeClaimVerdict.YIELD)
+    }
+
+    @Test
+    fun `movement under slop stays undecided`() {
+        assertThat(evaluateSwipeClaim(totalDx = 0f, totalDy = 0f, touchSlop = slop))
+            .isEqualTo(SwipeClaimVerdict.UNDECIDED)
+        assertThat(evaluateSwipeClaim(totalDx = 23f, totalDy = 2f, touchSlop = slop))
+            .isEqualTo(SwipeClaimVerdict.UNDECIDED)
+        assertThat(evaluateSwipeClaim(totalDx = 10f, totalDy = 23f, touchSlop = slop))
+            .isEqualTo(SwipeClaimVerdict.UNDECIDED)
+        // Exactly at slop is not past it, on either axis.
+        assertThat(evaluateSwipeClaim(totalDx = slop, totalDy = 0f, touchSlop = slop))
+            .isEqualTo(SwipeClaimVerdict.UNDECIDED)
+        assertThat(evaluateSwipeClaim(totalDx = 0f, totalDy = slop, touchSlop = slop))
+            .isEqualTo(SwipeClaimVerdict.UNDECIDED)
+    }
+
+    @Test
+    fun `horizontal movement just past slop claims only when it dominates`() {
+        assertThat(evaluateSwipeClaim(totalDx = 25f, totalDy = 24f, touchSlop = slop))
+            .isEqualTo(SwipeClaimVerdict.CLAIM)
+        // Vertical equals horizontal: the scroll keeps it.
+        assertThat(evaluateSwipeClaim(totalDx = 25f, totalDy = 25f, touchSlop = slop))
+            .isEqualTo(SwipeClaimVerdict.YIELD)
+    }
+}

--- a/app/src/test/kotlin/app/clearsms/ui/components/SwipeableMessageItemConventionTest.kt
+++ b/app/src/test/kotlin/app/clearsms/ui/components/SwipeableMessageItemConventionTest.kt
@@ -1,0 +1,57 @@
+package app.clearsms.ui.components
+
+import com.google.common.truth.Truth.assertWithMessage
+import org.junit.Test
+import java.io.File
+
+/**
+ * Source-level convention (the repo pattern for behaviour with no Compose UI
+ * test harness): the inbox row's swipe gesture must keep the discipline that
+ * fixes issue #16.
+ *
+ * Material3's SwipeToDismissBox claims a gesture as soon as horizontal
+ * movement alone crosses touch slop, so a slightly diagonal scroll flick
+ * swipes a row instead of scrolling the list. The row therefore drives its
+ * own pointer loop whose only claim/yield authority is the pure, unit-tested
+ * [evaluateSwipeClaim]. These assertions fail if someone reverts to
+ * SwipeToDismissBox or inlines ad-hoc slop math that would drift from the
+ * tested logic.
+ */
+class SwipeableMessageItemConventionTest {
+    private val source = File("src/main/kotlin/app/clearsms/ui/components/SwipeableMessageItem.kt").readText()
+
+    @Test
+    fun `the row does not use SwipeToDismissBox for gesture recognition`() {
+        assertWithMessage(
+            "SwipeableMessageItem must not delegate gesture recognition to SwipeToDismissBox: " +
+                "it claims on horizontal slop alone, which turns diagonal scroll flicks into swipes (issue #16)",
+        ).that(source)
+            .doesNotContain("SwipeToDismissBox(")
+    }
+
+    @Test
+    fun `gesture claiming goes through the shared axis-dominance verdict`() {
+        assertWithMessage("the pointer loop must consult the pure, unit-tested claim logic")
+            .that(source)
+            .contains("evaluateSwipeClaim(")
+        assertWithMessage("a YIELD verdict must abandon the gesture so the list scroll keeps it")
+            .that(source)
+            .contains("SwipeClaimVerdict.YIELD -> return@awaitEachGesture")
+        assertWithMessage("a gesture already consumed elsewhere (an active scroll) must never be claimed")
+            .that(source)
+            .contains("if (change.isConsumed) return@awaitEachGesture")
+    }
+
+    @Test
+    fun `trigger thresholds stay at the Material3 values this component replaced`() {
+        // The rewrite fixes gesture RECOGNITION; how far a recognised swipe
+        // must travel is deliberately unchanged. Changing these values is a
+        // product decision that must be taken (and reported) explicitly.
+        assertWithMessage("positional threshold must stay at SwipeToDismissBox's 56.dp")
+            .that(source)
+            .contains("SwipePositionalThreshold = 56.dp")
+        assertWithMessage("velocity threshold must stay at SwipeToDismissBox's 125.dp/s")
+            .that(source)
+            .contains("SwipeVelocityThreshold = 125.dp")
+    }
+}

--- a/app/src/test/kotlin/app/clearsms/ui/finance/FinanceSummaryBannerTest.kt
+++ b/app/src/test/kotlin/app/clearsms/ui/finance/FinanceSummaryBannerTest.kt
@@ -15,6 +15,7 @@ import app.clearsms.domain.model.OtpAutoDeletePolicy
 import app.clearsms.domain.model.OtpDisplaySize
 import app.clearsms.domain.model.StartDestination
 import app.clearsms.domain.model.SwipeAction
+import app.clearsms.domain.model.SwipeDeadZone
 import app.clearsms.domain.model.ThemeMode
 import app.clearsms.domain.model.TransactionType
 import app.clearsms.ui.alerts.AlertFilter
@@ -298,6 +299,10 @@ private class FakeSettingsRepository : SettingsRepository {
     override suspend fun setSwipeActionStart(value: SwipeAction) = Unit
 
     override val swipeActionEnd = MutableStateFlow(SwipeAction.DELETE)
+
+    override val swipeDeadZone = MutableStateFlow(SwipeDeadZone.DEFAULT)
+
+    override suspend fun setSwipeDeadZone(value: SwipeDeadZone) = Unit
 
     override suspend fun setSwipeActionEnd(value: SwipeAction) = Unit
 

--- a/app/src/test/kotlin/app/clearsms/ui/settings/SettingsCatalogTest.kt
+++ b/app/src/test/kotlin/app/clearsms/ui/settings/SettingsCatalogTest.kt
@@ -82,6 +82,9 @@ class SettingsCatalogTest {
                 "Default inbox filter",
                 "Swipe right action",
                 "Swipe left action",
+                // Directly under the two swipe-action rows it refines: the
+                // per-row band where a swipe never starts (issue #16).
+                "Swipe dead zone",
                 "Sort inbox again",
             ).inOrder()
         assertThat(bySection["Finance"])
@@ -158,10 +161,12 @@ class SettingsCatalogTest {
                 // Backup & restore: the automatic-backup directory row that
                 // gates the backup frequency.
                 "Backup location",
+                // Inbox: the per-row swipe dead zone editor (issue #16).
+                "Swipe dead zone",
             )
         val allTitles = SettingsItem.entries.map(::title)
 
-        // No row lost, none dropped: 32 survivors + 8 additions = 40 rows.
+        // No row lost, none dropped: 32 survivors + 9 additions = 41 rows.
         assertThat(allTitles.sorted()).isEqualTo((preReorgRows + newRows).sorted())
         // No duplicates: "Pill order" legitimately appears once per pills
         // screen (Inbox / Finance / Alerts); every other (section, title)

--- a/app/src/test/kotlin/app/clearsms/ui/settings/SwipeDeadZoneGeometryConventionTest.kt
+++ b/app/src/test/kotlin/app/clearsms/ui/settings/SwipeDeadZoneGeometryConventionTest.kt
@@ -1,0 +1,67 @@
+package app.clearsms.ui.settings
+
+import com.google.common.truth.Truth.assertWithMessage
+import org.junit.Test
+import java.io.File
+
+/**
+ * Source-level convention: the swipe gesture and the settings preview must
+ * derive the dead zone from ONE shared geometry source -
+ * [app.clearsms.domain.model.SwipeDeadZone.bounds] - so the translucent
+ * overlay the user tunes in Settings is exactly the area where swipes will
+ * not start. A preview that re-derived the rectangle from the raw percent
+ * fields could silently drift from the gesture; these assertions make that
+ * drift a test failure instead.
+ */
+class SwipeDeadZoneGeometryConventionTest {
+    private val srcRoot = File("src/main/kotlin/app/clearsms")
+
+    private val modelSource = File(srcRoot, "domain/model/SwipeDeadZone.kt").readText()
+    private val gestureSource = File(srcRoot, "ui/components/SwipeableMessageItem.kt").readText()
+    private val previewSource = File(srcRoot, "ui/settings/SwipeDeadZoneDialog.kt").readText()
+
+    @Test
+    fun `the gesture consults the shared gate and never re-derives geometry`() {
+        assertWithMessage("the pointer loop must ask SwipeDeadZone.blocksTouchAt")
+            .that(gestureSource)
+            .contains("deadZone.blocksTouchAt(")
+        assertWithMessage(
+            "the gesture must not rebuild the zone from raw percent fields - " +
+                "geometry lives only in SwipeDeadZone.bounds()",
+        ).that(gestureSource)
+            .doesNotContain("Percent")
+    }
+
+    @Test
+    fun `the preview overlay is drawn from the same bounds the gesture checks`() {
+        // Scope to the drawing composable: the dialog's sliders legitimately
+        // read the percent fields for EDITING, but DRAWING must use bounds().
+        val preview = previewSource.substringAfter("private fun DeadZonePreview").substringBefore("private fun MockInboxRow")
+        assertWithMessage("the preview must draw the rectangle from SwipeDeadZone.bounds()")
+            .that(preview)
+            .contains("zone.bounds()")
+        assertWithMessage(
+            "the preview must not re-derive the rectangle from raw percent fields - " +
+                "that is how a decorative overlay drifts from the real gesture",
+        ).that(preview)
+            .doesNotContain("Percent")
+    }
+
+    @Test
+    fun `blocksTouchAt itself is implemented on top of bounds`() {
+        val gate = modelSource.substringAfter("fun blocksTouchAt").substringBefore("fun encode")
+        assertWithMessage("SwipeDeadZone.blocksTouchAt must delegate to bounds(), the single geometry source")
+            .that(gate)
+            .contains("bounds() ?: return false")
+    }
+
+    @Test
+    fun `preview and sliders stay accessible`() {
+        assertWithMessage("the preview overlay needs a content description")
+            .that(previewSource)
+            .contains("settings_swipe_dead_zone_preview_description")
+        assertWithMessage("sliders need semantics so the zone is configurable without fine motor control")
+            .that(previewSource)
+            .contains("contentDescription = label")
+    }
+}


### PR DESCRIPTION
Closes the "swipe fires while I'm just scrolling" report (#16), where the only workaround so far was turning swipe gestures off entirely.

## Two layers, because the dead zone alone is a workaround

**1. Fix the real cause first.** A horizontal swipe was claiming the gesture without requiring horizontal movement to dominate vertical movement, so a scroll could turn into a swipe. The row now only claims a swipe once horizontal travel wins past touch slop. On its own this should fix the reporter's complaint.

**2. Then the dead zone the operator asked for**, as insurance for anyone who still wants it: a configurable central band where swipes are ignored, with position, width and height adjustable.

## The visual preview

Configuration is not numbers-only - the settings dialog renders a realistic 3-row inbox with the dead zone as a **translucent band over it**, updating live as you drag the sliders. The preview and the gesture code derive the band from one shared geometry source, with a test pinning that, so what you see cannot drift from what the gesture does.

Geometry is expressed in **percentages** of row width/height rather than dp so a configuration behaves the same across devices, and bounds are clamped so a zone can never silently swallow the whole row.

## Bug found during verification

Triggered swipes froze mid-return and never fired their action: a `LaunchedEffect` keyed on the swipe state called `animateTo(SETTLED)`, which flipped its own key, restarted the effect and cancelled the animation before the action ran. The action now happens in the gesture coroutine after `settle()`. Worth noting this was a **pre-existing latent bug** in the swipe path, surfaced by exercising it methodically rather than introduced here.

## Verification

- `ktlintCheck testDebugUnitTest lintDebug assembleDebug` green; `-PciRepro testDebugUnitTest --rerun-tasks` green; 1,959 tests, 0 failures
- on emulator: the overlay updates live at two different configurations; a swipe starting **inside** the band does nothing while one starting **outside** archives with its Undo snackbar; six fast vertical and diagonal flicks trigger nothing (all 12 seeded threads intact); with the zone **off** behaviour is exactly as before including Undo; settings survive a force-stop; long-press selection still works from inside the zone, and delete → recycle bin → restore is unaffected
